### PR TITLE
Change test/example to use a case insensitive regular expression

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,4 @@
 module.exports = {
-  'plugins': [
-    'html'
-  ],
   'env': {
     'browser': true,
     'commonjs': true,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,250 @@
+module.exports = {
+  'plugins': [
+    'html'
+  ],
+  'env': {
+    'browser': true,
+    'commonjs': true,
+    'es6': true,
+    'jasmine': true,
+    'jest': true,
+    'mocha': true,
+    'node': true
+  },
+  'extends': 'eslint:recommended',
+  'parser': 'babel-eslint',
+  'parserOptions': {
+    'sourceType': 'module'
+  },
+  'rules': {
+    'arrow-parens': [
+      'error',
+      'always'
+    ],
+    'arrow-spacing': 'error',
+    'block-scoped-var': 'error',
+    'block-spacing': [
+      'error',
+      'always'
+    ],
+    'brace-style': [
+      'error',
+      '1tbs'
+    ],
+    'comma-dangle': [
+      'error',
+      'always-multiline'
+    ],
+    'comma-spacing': 'error',
+    'comma-style': [
+      'error',
+      'last'
+    ],
+    'computed-property-spacing': [
+      'error',
+      'never'
+    ],
+    'curly': 'error',
+    'dot-notation': 'error',
+    'eol-last': 'error',
+    'func-call-spacing': [
+      'error',
+      'never'
+    ],
+    'implicit-arrow-linebreak': [
+      'error',
+      'beside'
+    ],
+    'indent': [
+      'error',
+      2,
+      {
+        'ArrayExpression': 'first',
+        'CallExpression': {
+          'arguments': 'first'
+        },
+        'FunctionDeclaration': {
+          'parameters': 'first'
+        },
+        'FunctionExpression': {
+          'parameters': 'first'
+        },
+        'ObjectExpression': 'first',
+        'SwitchCase': 1
+      }
+    ],
+    'key-spacing': [
+      'error',
+      {
+        'afterColon': true,
+        'beforeColon': false,
+        'mode': 'strict'
+      }
+    ],
+    'keyword-spacing': [
+      'error',
+      {
+        'after': true,
+        'before': true
+      }
+    ],
+    'linebreak-style': [
+      'error',
+      'unix'
+    ],
+    'lines-between-class-members': [
+      'error',
+      'always'
+    ],
+    'max-len': [
+      'error',
+      {
+        'code': 80,
+        'ignoreTemplateLiterals': true
+      }
+    ],
+    'multiline-ternary': [
+      'error',
+      'always-multiline'
+    ],
+    'no-console': 0,
+    'no-duplicate-imports': 'error',
+    'no-eval': 'error',
+    'no-floating-decimal': 'error',
+    'no-implicit-globals': 'error',
+    'no-implied-eval': 'error',
+    'no-lonely-if': 'error',
+    'no-multi-spaces': [
+      'error',
+      {
+        'ignoreEOLComments': true
+      }
+    ],
+    'no-multiple-empty-lines': 'error',
+    'no-return-assign': 'error',
+    'no-script-url': 'error',
+    'no-self-compare': 'error',
+    'no-sequences': 'error',
+    'no-shadow-restricted-names': 'error',
+    'no-tabs': 'error',
+    'no-trailing-spaces': 'error',
+    'no-undefined': 'error',
+    'no-unmodified-loop-condition': 'error',
+    'no-unused-vars': [
+      'error',
+      {
+        'argsIgnorePattern': '^_',
+        'varsIgnorePattern': '^_'
+      }
+    ],
+    'no-useless-computed-key': 'error',
+    'no-useless-concat': 'error',
+    'no-useless-constructor': 'error',
+    'no-useless-return': 'error',
+    'no-var': 'error',
+    'no-void': 'error',
+    'no-whitespace-before-property': 'error',
+    'object-curly-newline': [
+      'error',
+      {
+        'consistent': true
+      }
+    ],
+    'object-curly-spacing': [
+      'error',
+      'never'
+    ],
+    'object-property-newline': [
+      'error',
+      {
+        'allowMultiplePropertiesPerLine': true
+      }
+    ],
+    'operator-linebreak': [
+      'error',
+      'after'
+    ],
+    'padded-blocks': [
+      'error',
+      {
+        'blocks': 'never'
+      }
+    ],
+    'prefer-const': 'error',
+    'prefer-template': 'error',
+    'quote-props': [
+      'error',
+      'as-needed'
+    ],
+    'quotes': [
+      'error',
+      'single',
+      {
+        'allowTemplateLiterals': true
+      }
+    ],
+    'semi': [
+      'error',
+      'always'
+    ],
+    'semi-spacing': [
+      'error',
+      {
+        'after': true,
+        'before': false
+      }
+    ],
+    'semi-style': [
+      'error',
+      'last'
+    ],
+    'space-before-blocks': [
+      'error',
+      'always'
+    ],
+    'space-before-function-paren': [
+      'error',
+      {
+        'anonymous': 'never',
+        'asyncArrow': 'always',
+        'named': 'never'
+      }
+    ],
+    'space-in-parens': [
+      'error',
+      'never'
+    ],
+    'space-infix-ops': 'error',
+    'space-unary-ops': [
+      'error',
+      {
+        'nonwords': false,
+        'words': true
+      }
+    ],
+    'spaced-comment': [
+      'error',
+      'always',
+      {
+        'block': {
+          'balanced': true,
+          'exceptions': [
+            '*'
+          ]
+        }
+      }
+    ],
+    'switch-colon-spacing': [
+      'error',
+      {
+        'after': true,
+        'before': false
+      }
+    ],
+    'template-curly-spacing': [
+      'error',
+      'never'
+    ],
+    'yoda': 'error'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "command-line-args": "^5.0.2",
-    "eslint": "^5.13.0",
-    "eslint-plugin-html": "^5.0.3"
+    "eslint": "^5.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Probes a serial port to determine the type of device attached.",
   "main": "serial-prober.js",
   "scripts": {
+    "lint": "eslint .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -23,6 +24,9 @@
     "serialport": "^7.0.2"
   },
   "devDependencies": {
-    "command-line-args": "^5.0.2"
+    "babel-eslint": "^10.0.1",
+    "command-line-args": "^5.0.2",
+    "eslint": "^5.13.0",
+    "eslint-plugin-html": "^5.0.3"
   }
 }

--- a/serial-test.js
+++ b/serial-test.js
@@ -39,8 +39,8 @@ const PROBERS = [
     ],
     filter: [
       {
-        vendorId: '0403',
-        productId: '6015',
+        vendorId: /0403/i,
+        productId: /6015/i,
       },
     ],
   }),
@@ -74,8 +74,8 @@ const PROBERS = [
         // Devices like the UartSBee, use a generic FTDI chip and with
         // an XBee S2 programmed with the right firmware can act like
         // a Zigbee coordinator.
-        vendorId: '0403',
-        productId: '6001',
+        vendorId: /0403/i,
+        productId: /6001/i,
       },
     ],
   }),

--- a/serial-test.js
+++ b/serial-test.js
@@ -25,7 +25,7 @@ const PROBERS = [
       0x00,       // Reserved - set to zero
       0x05, 0x00, // Frame length
       0xed, 0xff, // CRC
-      0xc0        // END - SLIP framing
+      0xc0,       // END - SLIP framing
     ],
     probeRsp: [
       0xc0,       // END - SLIP framing
@@ -54,14 +54,14 @@ const PROBERS = [
       0x08,       // AT Command Request
       0x01,       // Frame ID
       0x41, 0x50, // AP - API Enable
-      0x65        // Checksum
+      0x65,       // Checksum
     ],
     probeRsp: [
       0x7e,       // Start of frame
       0x00, 0x06, // Payload length
       0x88,       // AT Command Response
       0x01,       // Frame ID
-      0x41, 0x50  // AP
+      0x41, 0x50, // AP
       // This would normally be followed by the current API mode, and a
       // checksum, but since we don't know those will be, we only match on
       // the first part of the response.


### PR DESCRIPTION
Not strictly needed for the particular example since the particular VID/PID only contain decimal digits.

However, making it use a regular expression makes things more obvious for people looking to add VIDs/PIDs which might contain alpha characters.

Different OSes may return upper or lower case alpha characters.