### PR TITLE
Keep going when a port fails to match

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serial-prober",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Probes a serial port to determine the type of device attached.",
   "main": "serial-prober.js",
   "scripts": {
@@ -24,8 +24,8 @@
     "serialport": "^7.0.2"
   },
   "devDependencies": {
-    "babel-eslint": "^10.0.1",
-    "command-line-args": "^5.0.2",
-    "eslint": "^5.13.0"
+    "babel-eslint": "^10.0.2",
+    "command-line-args": "^5.1.1",
+    "eslint": "^6.0.1"
   }
 }

--- a/serial-prober.js
+++ b/serial-prober.js
@@ -52,6 +52,7 @@ class SerialProber {
           this.lockAttempt++;
           if (this.lockAttempt >= MAX_OPEN_ATTEMPTS) {
             // Looks like somebody else has the port open.
+            DEBUG && console.error(err);
             reject(err);
           } else {
             this.lockTimer = setTimeout(() => {
@@ -60,6 +61,7 @@ class SerialProber {
           }
         } else {
           // Some other error (like access denied, etc.)
+          DEBUG && console.error(err);
           reject(err);
         }
         return;
@@ -151,10 +153,8 @@ class SerialProber {
             break;  // probe succeeded.
           } catch (err) {
             // probe failed.
-            const msg = `Port ${port.comName} ` +
-                        `looks like it might be a/an ${prober.param.name} ` +
-                        `dongle, but it couldn't be opened.`;
-            throw new Error(`${msg} ${err}`);
+            console.error(err);
+            // keep going since there are other ports to check.
           }
         } else {
           DEBUG && console.log('SerialProber:', port.comName,
@@ -177,7 +177,7 @@ class SerialProber {
     for (const filter of this.param.filter) {
       let match = true;
       for (const [key, re] of Object.entries(filter)) {
-        if (!port.hasOwnProperty(key)) {
+        if (!Object.prototype.hasOwnProperty.call(port, key)) {
           match = false;
           break;
         }

--- a/serial-test.js
+++ b/serial-test.js
@@ -42,6 +42,10 @@ const PROBERS = [
         vendorId: /0403/i,
         productId: /6015/i,
       },
+      {
+        vendorId: /1cf1/i,
+        productId: /0030/i,
+      },
     ],
   }),
   new SerialProber({
@@ -134,7 +138,7 @@ if (options.list) {
       }
     }
   }).catch((err) => {
-    console.error('' + err);
+    console.error(`${err}`);
     console.log('Done all probes - nothing matched');
   });
 }


### PR DESCRIPTION
If a probe fails for some reason, don't throw an error.
Just report it and keep going, since we might not even
be interested in the port that failed the probe.

This also cleans up a couple of linter warnings.